### PR TITLE
skhd: highly prioritize the +alt hotkey

### DIFF
--- a/.skhdrc
+++ b/.skhdrc
@@ -3,6 +3,7 @@
 # mpmsimo custom hotkeys
 # kitty (ctrl+shift)
 # yabai (alt+ - for window movement)
+# I prefer displays vs. spaces. I do not use MacOS workspaces too often.
 # =========================================
 # reload hotkey config 
 alt + cmd + ctrl - r : khd -e "reload"
@@ -24,19 +25,39 @@ alt + cmd - n : yabai -m space --create && \
                 index="$(yabai -m query --spaces --display | jq 'map(select(."native-fullscreen" == 0))[-1].index')" && \
                 yabai -m space --focus "${index}"
 
+# destroy desktop
+alt + cmd - w : yabai -m space --destroy
+
 # =========================================
 # Yabai - vim-inspired movement (prev/next)
-# alt+ (shift, ctrl, cmd)
 # =========================================
 ### (base) - screen window | focus
-# Focus screen window
 alt - h : yabai -m window --focus west
 alt - j : yabai -m window --focus south
 alt - k : yabai -m window --focus north
 alt - l : yabai -m window --focus east
 
+### (shift) - screen window | swap
+alt + shift - h : yabai -m window --swap west
+alt + shift - j : yabai -m window --swap south
+alt + shift - k : yabai -m window --swap north
+alt + shift - l : yabai -m window --swap east
 
+### (ctrl) - display | focus 
+alt + ctrl - h  : yabai -m display --focus prev
+alt + ctrl - l  : yabai -m display --focus next
 
+### (cmd) display | focus & follow 
+# send window to monitor and follow focus
+alt + cmd - h  : yabai -m window --display prev; yabai -m display --focus prev
+alt + cmd - l  : yabai -m window --display next; yabai -m display --focus next
+
+# =========================================
+# Yabai (Sorted by hotkey combination)
+# alt+ (shift, ctrl, cmd)
+# =========================================
+
+#=== alt + base
 # toggle desktop offset
 alt - a : yabai -m space --toggle padding; yabai -m space --toggle gap
 
@@ -74,13 +95,7 @@ alt - x : yabai -m space --mirror x-axis
 # mirror tree y-axis
 alt - y : yabai -m space --mirror y-axis
 
-### (shift) - screen window | swap
-# Swap window in screen
-alt + shift - h : yabai -m window --swap west
-alt + shift - j : yabai -m window --swap south
-alt + shift - k : yabai -m window --swap north
-alt + shift - l : yabai -m window --swap east
-
+#=== alt + shift
 # increase window size
 alt + shift - a : yabai -m window --resize left:-20:0
 alt + shift - d : yabai -m window --resize right:20:0
@@ -103,38 +118,15 @@ alt + shift - y: yabai -m window --grid 1:2:0:0:1:1
 # Right-half
 alt + shift - o: yabai -m window --grid 1:2:1:0:1:1
 
-### (ctrl) screen window | resize
-# Balance size of windows (not needed for now)
-alt + ctrl - h  : yabai -m display --focus prev
-alt + ctrl - l  : yabai -m display --focus next
-alt + ctrl - h : yabai -m window --insert west
-alt + ctrl - j : yabai -m window --insert south
-alt + ctrl - k : yabai -m window --insert north
-alt + ctrl - l : yabai -m window --insert east
-
+#=== alt + ctrl
 # change layout of desktop
 alt + ctrl - a : yabai -m space --layout bsp
 alt + ctrl - d : yabai -m space --layout float
 
-### (cmd) display window | swap
-# destroy desktop
-alt + cmd - w : yabai -m space --destroy
-#
-# send window to monitor and follow focus
-ctrl + cmd - h  : yabai -m window --display prev; yabai -m display --focus prev
-ctrl + cmd - l  : yabai -m window --display recent; yabai -m display --focus recent
-
-# fast focus desktop
-alt + cmd - h : yabai -m space --focus prev
-alt + cmd - l : yabai -m space --focus next
-
-# move window to space then focus space
-alt + cmd - h : yabai -m window --space prev; yabai -m space --focus prev
-alt + cmd - l : yabai -m window --space next; yabai -m space --focus next
-
+#=== alt + cmd
 
 # =========================================
-# Yabai (Defaults)
+# Yabai (unused)
 # =========================================
 # reorient 
 #shift + cmd - h : yabai -m window --warp west

--- a/.skhdrc
+++ b/.skhdrc
@@ -1,7 +1,11 @@
 # =========================================
-# Useful keybinds
+# .skhdrc
+# mpmsimo custom hotkeys
+# kitty (ctrl+shift)
+# yabai (alt+ - for window movement)
 # =========================================
-cmd + alt + ctrl - r : khd -e "reload"
+# reload hotkey config 
+alt + cmd + ctrl - r : khd -e "reload"
 
 # open terminal, blazingly fast compared to iTerm/Hyper
 cmd - return : /Applications/Kitty.app/Contents/MacOS/kitty --single-instance -d ~
@@ -16,94 +20,34 @@ shift + cmd - n : yabai -m space --create && \
                   yabai -m space --focus "${index}"
 
 # create desktop and follow focus - uses jq for parsing json (brew install jq)
-cmd + alt - n : yabai -m space --create && \
+alt + cmd - n : yabai -m space --create && \
                 index="$(yabai -m query --spaces --display | jq 'map(select(."native-fullscreen" == 0))[-1].index')" && \
                 yabai -m space --focus "${index}"
 
-# send window to monitor and follow focus
-ctrl + cmd - h  : yabai -m window --display prev; yabai -m display --focus prev
-ctrl + cmd - l  : yabai -m window --display recent; yabai -m display --focus recent
-ctrl + cmd - c  : yabai -m window --display next; yabai -m display --focus next
-ctrl + cmd - 1  : yabai -m window --display 1; yabai -m display --focus 1
-ctrl + cmd - 2  : yabai -m window --display 2; yabai -m display --focus 2
-ctrl + cmd - 3  : yabai -m window --display 3; yabai -m display --focus 3
-
 # =========================================
-# Yabai (Window)
+# Yabai - vim-inspired movement (prev/next)
+# alt+ (shift, ctrl, cmd)
 # =========================================
-# focus
+### (base) - screen window | focus
+# Focus screen window
 alt - h : yabai -m window --focus west
 alt - j : yabai -m window --focus south
 alt - k : yabai -m window --focus north
 alt - l : yabai -m window --focus east
 
 
-# swap windows
-shift + alt - h : yabai -m window --swap west
-shift + alt - j : yabai -m window --swap south
-shift + alt - k : yabai -m window --swap north
-shift + alt - l : yabai -m window --swap east
 
-# reorient 
-shift + cmd - h : yabai -m window --warp west
-shift + cmd - j : yabai -m window --warp south
-shift + cmd - k : yabai -m window --warp north
-shift + cmd - l : yabai -m window --warp east
-
-# make floating window fill screen
-shift + alt - up     : yabai -m window --grid 1:1:0:0:1:1
-
-# make floating window fill left-half of screen
-shift + alt - left   : yabai -m window --grid 1:2:0:0:1:1
-
-# make floating window fill right-half of screen
-shift + alt - right  : yabai -m window --grid 1:2:1:0:1:1
-
-# move window
-shift + ctrl - a : yabai -m window --move rel:-20:0
-shift + ctrl - s : yabai -m window --move rel:0:20
-shift + ctrl - w : yabai -m window --move rel:0:-20
-shift + ctrl - d : yabai -m window --move rel:20:0
-
-# increase window size
-shift + alt - a : yabai -m window --resize left:-20:0
-shift + alt - s : yabai -m window --resize bottom:0:20
-shift + alt - w : yabai -m window --resize top:0:-20
-shift + alt - d : yabai -m window --resize right:20:0
-
-# decrease window size
-shift + cmd - a : yabai -m window --resize left:20:0
-shift + cmd - s : yabai -m window --resize bottom:0:-20
-shift + cmd - w : yabai -m window --resize top:0:20
-shift + cmd - d : yabai -m window --resize right:-20:0
-
-# set insertion point in focused container
-ctrl + alt - h : yabai -m window --insert west
-ctrl + alt - j : yabai -m window --insert south
-ctrl + alt - k : yabai -m window --insert north
-ctrl + alt - l : yabai -m window --insert east
+# toggle desktop offset
+alt - a : yabai -m space --toggle padding; yabai -m space --toggle gap
 
 # toggle window parent zoom
 alt - d : yabai -m window --toggle zoom-parent
 
-# toggle window fullscreen zoom
-alt - f : yabai -m window --toggle zoom-fullscreen
-
-# toggle window native fullscreen
-shift + alt - f : yabai -m window --toggle native-fullscreen
-
-# toggle window border
-shift + alt - b : yabai -m window --toggle border
-
 # toggle window split type
 alt - e : yabai -m window --toggle split
 
-# float / unfloat window and center on screen
-alt - t : yabai -m window --toggle float;\
-          yabai -m window --grid 4:4:1:1:2:2
-
-# toggle sticky (show on all spaces)
-alt - s : yabai -m window --toggle sticky
+# toggle window fullscreen zoom
+alt - f : yabai -m window --toggle zoom-fullscreen
 
 # toggle topmost (keep above other windows)
 alt - o : yabai -m window --toggle topmost
@@ -114,54 +58,98 @@ alt - p : yabai -m window --toggle sticky;\
           yabai -m window --toggle border;\
           yabai -m window --toggle pip
 
-# =========================================
-# Yabai (Space)
-# =========================================
-
-cmd - h : yabai -m window --space prev; yabai -m space --focus prev
-cmd - l : yabai -m window --space next; yabai -m space --focus next
-
-# destroy desktop
-cmd + alt - w : yabai -m space --destroy
-
-# fast focus desktop
-cmd + alt - x : yabai -m space --focus recent
-cmd + alt - h : yabai -m space --focus prev
-cmd + alt - l : yabai -m space --focus next
-cmd + alt - 1 : yabai -m space --focus 1
-cmd + alt - 2 : yabai -m space --focus 2
-cmd + alt - 3 : yabai -m space --focus 3
-
-# send window to desktop and follow focus
-shift + cmd - 1 : yabai -m window --space  1; yabai -m space --focus 1
-shift + cmd - 2 : yabai -m window --space  2; yabai -m space --focus 2
-shift + cmd - 3 : yabai -m window --space  3; yabai -m space --focus 3
-
 # rotate tree
 alt - r : yabai -m space --rotate 90
 
-# mirror tree y-axis
-alt - y : yabai -m space --mirror y-axis
+# toggle sticky (show on all spaces)
+alt - s : yabai -m window --toggle sticky
+
+# float / unfloat window and center on screen
+alt - t : yabai -m window --toggle float;\
+          yabai -m window --grid 4:4:1:1:2:2
 
 # mirror tree x-axis
 alt - x : yabai -m space --mirror x-axis
 
-# toggle desktop offset
-alt - a : yabai -m space --toggle padding; yabai -m space --toggle gap
+# mirror tree y-axis
+alt - y : yabai -m space --mirror y-axis
+
+### (shift) - screen window | swap
+# Swap window in screen
+alt + shift - h : yabai -m window --swap west
+alt + shift - j : yabai -m window --swap south
+alt + shift - k : yabai -m window --swap north
+alt + shift - l : yabai -m window --swap east
+
+# increase window size
+alt + shift - a : yabai -m window --resize left:-20:0
+alt + shift - d : yabai -m window --resize right:20:0
+alt + shift - w : yabai -m window --resize bottom:0:20
+alt + shift - s : yabai -m window --resize top:0:-20
+
+# toggle window border
+alt + shift - b : yabai -m window --toggle border
+
+# toggle window native fullscreen
+alt + shift - f : yabai -m window --toggle native-fullscreen
+
+## Floating window in screen
+# Full screen
+alt + shift - t: yabai -m window --grid 1:1:0:0:1:1
+
+# Left-half
+alt + shift - y: yabai -m window --grid 1:2:0:0:1:1
+
+# Right-half
+alt + shift - o: yabai -m window --grid 1:2:1:0:1:1
+
+### (ctrl) screen window | resize
+# Balance size of windows (not needed for now)
+alt + ctrl - h  : yabai -m display --focus prev
+alt + ctrl - l  : yabai -m display --focus next
+alt + ctrl - h : yabai -m window --insert west
+alt + ctrl - j : yabai -m window --insert south
+alt + ctrl - k : yabai -m window --insert north
+alt + ctrl - l : yabai -m window --insert east
 
 # change layout of desktop
-ctrl + alt - a : yabai -m space --layout bsp
-ctrl + alt - d : yabai -m space --layout float
+alt + ctrl - a : yabai -m space --layout bsp
+alt + ctrl - d : yabai -m space --layout float
 
-# balance size of windows
-shift + alt - 0 : yabai -m space --balance
+### (cmd) display window | swap
+# destroy desktop
+alt + cmd - w : yabai -m space --destroy
+#
+# send window to monitor and follow focus
+ctrl + cmd - h  : yabai -m window --display prev; yabai -m display --focus prev
+ctrl + cmd - l  : yabai -m window --display recent; yabai -m display --focus recent
+
+# fast focus desktop
+alt + cmd - h : yabai -m space --focus prev
+alt + cmd - l : yabai -m space --focus next
+
+# move window to space then focus space
+alt + cmd - h : yabai -m window --space prev; yabai -m space --focus prev
+alt + cmd - l : yabai -m window --space next; yabai -m space --focus next
+
 
 # =========================================
-# Yabai (Display)
+# Yabai (Defaults)
 # =========================================
-ctrl + alt - x  : yabai -m display --focus recent
-ctrl + alt - h  : yabai -m display --focus prev
-ctrl + alt - l  : yabai -m display --focus next
-ctrl + alt - 1  : yabai -m display --focus 1
-ctrl + alt - 2  : yabai -m display --focus 2
-ctrl + alt - 3  : yabai -m display --focus 3
+# reorient 
+#shift + cmd - h : yabai -m window --warp west
+#shift + cmd - j : yabai -m window --warp south
+#shift + cmd - k : yabai -m window --warp north
+#shift + cmd - l : yabai -m window --warp east
+
+# move window
+#shift + ctrl - a : yabai -m window --move rel:-20:0
+#shift + ctrl - s : yabai -m window --move rel:0:20
+#shift + ctrl - w : yabai -m window --move rel:0:-20
+#shift + ctrl - d : yabai -m window --move rel:20:0
+
+# decrease window size
+#shift + cmd - a : yabai -m window --resize left:20:0
+#shift + cmd - s : yabai -m window --resize bottom:0:-20
+#shift + cmd - w : yabai -m window --resize top:0:20
+#shift + cmd - d : yabai -m window --resize right:-20:0

--- a/README.md
+++ b/README.md
@@ -37,8 +37,8 @@ l = right (next window/desktop)
 I do believe modifiers should be unique to the application, as this has bit me in the past.
 
 * kitty (ctrl+shift)
-* skhd (shift+alt, alt, ctrl+alt)
-* yabai (ctrl+shift, 
+* skhd (alt+)
+* yabai (ctrl+!shift, cmd+)
 * vim (leader, and vim specifics)
 
 ## Installation
@@ -46,8 +46,8 @@ The setup script is intended to be used when a new system is being installed.
 
 ### Macbook
 ```
+> clone this repo to $HOME
 cd ~/dotfiles
-> clone this repo
 bash dotfiles.sh
 ```
 


### PR DESCRIPTION
Reorganize the `skhd` hotkey configuration.

This will allow me to be more productive when using multiple monitors.

alt+ is the main key.
- base (screen focus)
- shift (screen swap + focus)
- ctrl (desktop focus)
- cmd (desktop swap + focus)
